### PR TITLE
Add tkl-webcp landing page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
-WEBMIN_FW_TCP_INCOMING = 22 80 443 12320 12321
+WEBMIN_FW_TCP_INCOMING = 22 80 443 12321
 
+include $(FAB_PATH)/common/mk/turnkey/nginx.mk
+include $(FAB_PATH)/common/mk/turnkey/tkl-webcp.mk
 include $(FAB_PATH)/common/mk/turnkey.mk

--- a/changelog
+++ b/changelog
@@ -3,6 +3,9 @@ turnkey-gameserver-18.0 (1) turnkey; urgency=low
   * Update dependencies for new release - closes #1929.
     [Stefan Davis <stefan@turnkeylinux.org>]
 
+  * Include landing page with basic info and links - based on tkl-webcp.
+    [Jeremy Davis <jeremy@turnkeylinux.org>]
+
   * Confconsole: bugfix broken DNS-01 Let's Encrypt challenge- closes #1876 &
     #1895.
     [Jeremy Davis <jeremy@turnkeylinux.org>]
@@ -74,7 +77,7 @@ turnkey-gameserver-18.0 (1) turnkey; urgency=low
     - Improve turnkey-artisan so that it works reliably in cron jobs (only
       Laravel based LAMP apps).
 
- -- Jeremy Davis <jeremy@turnkeylinux.org>  Fri, 19 Apr 2024 00:26:25 +0000
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Wed, 24 Apr 2024 22:13:39 +0000
 
 turnkey-gameserver-17.1 (1) turnkey; urgency=low
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -32,3 +32,6 @@ echo "DenyUsers	$GAMEUSER" >> /etc/ssh/sshd_config
 git clone --depth=1 "$GAME_REPO_URL" "$GAME_REPO_DIR"
 
 mkdir -p /var/log/gameserver
+
+# remove unused/unneeded images
+rm -f /var/www/images/{adminer.png,shell.png}

--- a/overlay/var/www/index.html
+++ b/overlay/var/www/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+
+<html lang="en">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <meta http-equiv="Content-Style-Type" content="text/css">
+        <meta http-equiv="Content-Script-Type" content="text/javascript">
+
+        <title>TurnKey GameServer</title>
+
+        <link rel="stylesheet" href="css/ui.tabs.css" type="text/css" media="print, projection, screen">
+        <link rel="stylesheet" href="css/base.css" type="text/css">
+
+        <script src="js/jquery-1.2.6.js" type="text/javascript"></script>
+        <script src="js/ui.core.js" type="text/javascript"></script>
+        <script src="js/ui.tabs.js" type="text/javascript"></script>
+        <script type="text/javascript">
+            $(function() {
+                $('#container-1 > ul').tabs({ fx: { opacity: 'toggle'} });
+            });
+        </script>
+        <script type="text/javascript">
+            jQuery(document).ready(function($) {
+              https = "https://"+window.location.hostname;
+              $("a[id='webmin']").attr('href', https+":12321");
+            });
+        </script>
+    </head>
+
+    <body>
+        <h1>TurnKey GameServer</h1>
+
+        <div id="container-1">
+            <ul>
+                <li><a href="#cp"><span>Control Panel</span></a></li>
+                <li><a href="#ref"><span>Quick reference</span></a></li>
+            </ul>
+            <div id="cp">
+                <div class="fragment-content">
+                    <div>
+                        <a id="webmin" href="">
+                        <img src="images/webmin.png"/>Webmin</a>
+                    </div>
+                    <div></div>
+                    <div></div>
+                    <div></div>
+                    <div></div>
+
+                    <h2>Resources and references</h2>
+                    <ul>
+                        <li><a href="https://github.com/turnkeylinux-apps/gameserver/blob/master/docs/usage.rst">
+                            TurnKey GameServer overview docs</a></li>
+                        <li><a href="https://github.com/jesinmat/linux-gameservers?tab=readme-ov-file#linux-gameservers">
+                            GameServer LinuxGSM wrapper script docs</a></li>
+
+                        <li><a href="https://linuxgsm.com/">Linux GSM Homepage</a></li>
+                        <li><a href="https://www.turnkeylinux.org/gameserver">
+                            TurnKey GameServer appliance page inc release notes</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div id="ref">
+                <div class="fragment-content">
+                    <p>Note to AWS Marketplace users, who have NOT <a
+                    href="https://www.turnkeylinux.org/awsmp#root">enabled
+                    root</a>:
+                    <br />some commands may require root privileges, so may need to be prefixed with
+                    <code>sudo</code>.</p>
+                    <h3>Getting started</h3>
+                    <p>Access GameServer CLI using SSH or Webmin &gt;&gt; Tools &gt;&gt; Terminal</p>
+                    <p>Then follow the notes in the <a href="">Usage docs</a>.</p>
+                    <p>For more info, please see the
+                    <a href="https://github.com/jesinmat/linux-gameservers?tab=readme-ov-file#linux-gameservers">
+                    GameServer LinuxGSM wrapper script docs</a> other docs:</p>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/plan/main
+++ b/plan/main
@@ -1,5 +1,7 @@
 #include <turnkey/base>
 
+nginx
+
 mailutils
 bzip2
 binutils


### PR DESCRIPTION
Fixes failing clicksnap screenshots by providing default landing page by leveraging common tkl-webcp.