### PR TITLE
fixing missing link in 'getting started' info on landing page

### DIFF
--- a/overlay/var/www/index.html
+++ b/overlay/var/www/index.html
@@ -68,7 +68,8 @@
                     <code>sudo</code>.</p>
                     <h3>Getting started</h3>
                     <p>Access GameServer CLI using SSH or Webmin &gt;&gt; Tools &gt;&gt; Terminal</p>
-                    <p>Then follow the notes in the <a href="">Usage docs</a>.</p>
+                    <p>Then follow the notes in the <a href="https://github.com/turnkeylinux-apps/gameserver/blob/master/docs/usage.rst">
+                        Usage docs</a>.</p>
                     <p>For more info, please see the
                     <a href="https://github.com/jesinmat/linux-gameservers?tab=readme-ov-file#linux-gameservers">
                     GameServer LinuxGSM wrapper script docs</a> other docs:</p>


### PR DESCRIPTION
Following @Elyviere's recent gameserver improvements I just noticed a missing link on the landing page.